### PR TITLE
docs: 补充开源安全要求 (Security and privacy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ pnpm dev
 ## Issue
 有任何问题可以提交 github issue，我们会定期 check 解决。
 
+## Security and privacy
+This project takes security seriously.
+For vulnerability reporting and supported versions, see [SECURITY.md](SECURITY.md)
+
 ## License
 ```text
 MIT License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+## Security and privacy
+
+If you discover potential security issues in the project, or believe you may have found a security issue, please notify the ByteDance security team through our [security center](https://security.bytedance.com/src/) or [vulnerability reporting email](mailto:src@bytedance.com). Please do not create public GitHub Issues.
+
+We will assess the vulnerability based on the Common Vulnerability Scoring System (CVSS 3.1). The security team will keep you updated on key progress and may request further information or guidance from you. You are welcome to contact us via the email or website mentioned above to ask questions or discuss disclosure matters.
+
+To protect the security of our customers, ByteDance requests that you do not publish or share information regarding the vulnerability in any public forum, nor publish or share data involving users, until the vulnerability has been remediated and our users have been notified. Please understand that the time required for remediation depends on the severity of the vulnerability and the scope of the impact.
+
+Individuals, companies, and security teams may wish to publish security advisories on their own websites or other forums. Please contact us via the email or website mentioned above prior to publication to discuss the information that can be disclosed and to coordinate the disclosure timeline.
+
+## Bug Bounty Reward
+
+[For the policy of bug bounty reward](https://bytedance.larkoffice.com/docx/ZstQd7bbooDctqxBCAmcFasOngd), if you have any questions about the rules, please contact [https://src.bytedance.com/home](https://src.bytedance.com/home) for consultation.


### PR DESCRIPTION
在 README 增加 Security and privacy 章节，并新增 SECURITY.md 说明漏洞上报与披露流程。